### PR TITLE
Add a preference menu and 'Auto Overwrite'

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 			{ "path": "./scripts/classes/editor/_editor.lua" },
 			{ "path": "./scripts/classes/editor/rendering.lua" },
 			{ "path": "./scripts/classes/editor/state.lua" },
+			{ "path": "./scripts/classes/preferences.lua" },
 			{ "path": "./scripts/classes/statesprite.lua" },
 			{ "path": "./scripts/classes/widget.lua" },
 			{ "path": "./scripts/functions/other.lua" },

--- a/scripts/classes/editor/_editor.lua
+++ b/scripts/classes/editor/_editor.lua
@@ -311,7 +311,7 @@ function Editor:onbeforecommand(ev)
 				if not state_sprite:save() then
 					ev.stopPropagation()
 				end
-				if Preferences.getAutoOverwrite() then
+				if Preferences.getAutoOverwrite and Preferences.getAutoOverwrite() then
 					self:save(true)
 				end
 				break

--- a/scripts/classes/editor/_editor.lua
+++ b/scripts/classes/editor/_editor.lua
@@ -106,11 +106,11 @@ function Editor:save_warning()
 	local result = 0
 
 	local dialog = Dialog {
-		title = "Warning",
+		title = "DMI Editor - Warning",
 	}
 
 	dialog:label {
-		text = "Save changes to the sprite",
+		text = "Save changes to the DMI",
 		focus = true
 	}
 
@@ -266,21 +266,28 @@ end
 --- Saves the current DMI file.
 --- If the DMI file is not set, the function returns without doing anything.
 --- Displays a success or failure message using the Aseprite app.alert function.
+--- @param no_dialog boolean|nil If true, skips the save dialog and overwrites the current file
 --- @return boolean success Whether the DMI file has been saved. May still return true even if the file has not been saved successfully.
-function Editor:save()
-	if not self.dmi then return false end
+function Editor:save(no_dialog)
+    if not self.dmi then return false end
 
-	local path = self:path()
-	local filename, error = libdmi.save_dialog("Save File", app.fs.fileTitle(path), app.fs.filePath(path))
-	if #filename > 0 and not error then
-		self.save_path = filename
-		local _, error = libdmi.save_file(self.dmi, filename --[[@as string]])
-		if not error then
-			self.modified = false
-		end
-		return true
-	end
-	return false
+    local path = self:path()
+    local filename = path
+    local error
+
+    if not no_dialog then
+        filename, error = libdmi.save_dialog("Save File", app.fs.fileTitle(path), app.fs.filePath(path))
+    end
+
+    if (#filename > 0) and not error then
+        self.save_path = filename
+        local _, error = libdmi.save_file(self.dmi, filename --[[@as string]])
+        if not error then
+            self.modified = false
+        end
+        return true
+    end
+    return false
 end
 
 --- Returns the path of the file to be saved.
@@ -303,6 +310,9 @@ function Editor:onbeforecommand(ev)
 			if app.sprite == state_sprite.sprite then
 				if not state_sprite:save() then
 					ev.stopPropagation()
+				end
+				if Preferences.getAutoOverwrite() then
+					self:save(true)
 				end
 				break
 			end

--- a/scripts/classes/preferences.lua
+++ b/scripts/classes/preferences.lua
@@ -1,19 +1,18 @@
---- @class Preferences
+
 Preferences = {}
+
+--- Initializes the Preferences
+
+-- Store the plugin object in the Preferences class
+Preferences.plugin = plugin
+
+-- Initialize default preferences if not set
+if not Preferences.plugin.preferences.auto_overwrite then
+    Preferences.plugin.preferences.auto_overwrite = false
+end
 
 --- Shows the preferences dialog.
 function Preferences.show(plugin)
-    -- Store the plugin object in the Preferences class
-    Preferences.plugin = plugin
-
-    -- Initialize default preferences if not set
-    if not Preferences.plugin.preferences.auto_overwrite then
-        Preferences.plugin.preferences.auto_overwrite = false
-    end
-    -- if not Preferences.plugin.preferences.auto_flatten then
-    --     Preferences.plugin.preferences.auto_flatten = false
-    -- end
-
     local dialog = Dialog {
         title = "DMI Editor Preferences"
     }

--- a/scripts/classes/preferences.lua
+++ b/scripts/classes/preferences.lua
@@ -1,0 +1,62 @@
+--- @class Preferences
+Preferences = {}
+
+--- Shows the preferences dialog.
+function Preferences.show(plugin)
+    -- Store the plugin object in the Preferences class
+    Preferences.plugin = plugin
+
+    -- Initialize default preferences if not set
+    if not Preferences.plugin.preferences.auto_overwrite then
+        Preferences.plugin.preferences.auto_overwrite = false
+    end
+    -- if not Preferences.plugin.preferences.auto_flatten then
+    --     Preferences.plugin.preferences.auto_flatten = false
+    -- end
+
+    local dialog = Dialog {
+        title = "DMI Editor Preferences"
+    }
+
+    dialog:check {
+        id = "auto_overwrite",
+        text = "Overwrite source DMI files when saving an iconstate.",
+        selected = Preferences.plugin.preferences.auto_overwrite,
+    }
+
+    -- dialog:newrow()
+
+    -- dialog:check {
+    --     id = "auto_flatten",
+    --     text = "Flatten layers downwards into directional layers when saving an iconstate.",
+    --     selected = Preferences.plugin.preferences.auto_flatten,
+    -- }
+
+    dialog:button {
+        text = "&OK",
+        focus = true,
+        onclick = function()
+            Preferences.plugin.preferences.auto_overwrite = dialog.data.auto_overwrite
+            -- Preferences.plugin.preferences.auto_flatten = dialog.data.auto_flatten
+            dialog:close()
+        end
+    }
+
+    dialog:button {
+        text = "&Cancel",
+        onclick = function()
+            dialog:close()
+        end
+    }
+
+    dialog:show {
+        wait = false
+    }
+end
+
+--- Gets whether auto-overwrite is enabled
+function Preferences.getAutoOverwrite()
+    return Preferences.plugin.preferences.auto_overwrite or false
+end
+
+return Preferences

--- a/scripts/classes/statesprite.lua
+++ b/scripts/classes/statesprite.lua
@@ -129,7 +129,7 @@ function StateSprite:save_warning()
 	local result = 0
 
 	local dialog = Dialog {
-		title = "Warning",
+		title = "DMI Editor - Warning",
 	}
 
 	local unnamed = false
@@ -138,7 +138,7 @@ function StateSprite:save_warning()
 		unnamed = true
 	end
 
-	local text = "Save changes to the sprite " .. (not unnamed and ('"' .. self.state.name .. '" ') or '') .. 'state of "' .. app.fs.fileName(self.editor:path()) .. '" before closing?'
+	local text = "Save changes to the iconstate " .. (not unnamed and ('"' .. self.state.name .. '" ') or '') .. 'of "' .. app.fs.fileName(self.editor:path()) .. '" before closing?'
 	local lines = string.split_lines(text, 36)
 
 	for i, line in ipairs(lines) do

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -144,6 +144,15 @@ function init(plugin)
 	}
 
 	plugin:newCommand {
+		id = "dmi_preferences",
+		title = "Preferences",
+		group = "dmi_editor",
+		onclick = function()
+			Preferences.show(plugin)
+		end,
+	}
+
+	plugin:newCommand {
 		id = "dmi_report_issue",
 		title = "Report Issue",
 		group = "dmi_editor",


### PR DESCRIPTION
Auto Overwrite - Overwrite source DMI files when saving an iconstate.

This is to make it so you don't have click the `Save` button in the editor window every time and just hit control S.

There's also some requested readability improvements.