### PR TITLE
Auto Flattening On Save

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-> [!WARNING]
-> ⚠ This project is no longer maintained by the creator, and has been taken under stewardship of the SS13 org to provide small updates and merge PRs. Don't expect significant developer additions. ⚠
+> [!NOTE]
+> This project is no longer maintained by the original creator, and has been taken under stewardship of the SS13 org to provide small updates and allow for community support.
 
 # DMI Editor for Aseprite
 
@@ -52,4 +52,4 @@ Push a tag like `v1.0.8` via `git`, after changing the Cargo.toml and package.js
 
 **GPLv3**, for more details see the [LICENSE](./LICENSE).
 
-Originally created by `Seefaaa`.
+Originally created by [Seefaaa](https://github.com/Seefaaa).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ In Aseprite's timeline, new frames can be added and delays between frames can be
 
 The DMI file may be expanded, resized, or cropped via the `File > DMI Editor` menu. It should be noted that the active sprite must be a DMI state in order to utilise these commands.
 
+### Plugin Preferences
+Under the `File > DMI Editor` menu, there is an `Extensions` menu which contains various options:
+
+- **Auto Overwrite**: Automatically overwrites the source DMI file when saving an iconstate.
+- **Auto Flatten** *(Enabled by Default)*: Automatically flattens layers downward into directional layers when saving an iconstate, allowing you to fully use Aseprite layers.
+
 ## Building the Project
 
 ### Requirements

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
 	"contributes": {
 		"scripts": [
 			{ "path": "./scripts/classes/cache.lua" },
+			{ "path": "./scripts/classes/preferences.lua" },
 			{ "path": "./scripts/classes/editor/_editor.lua" },
 			{ "path": "./scripts/classes/editor/rendering.lua" },
 			{ "path": "./scripts/classes/editor/state.lua" },
-			{ "path": "./scripts/classes/preferences.lua" },
 			{ "path": "./scripts/classes/statesprite.lua" },
 			{ "path": "./scripts/classes/widget.lua" },
 			{ "path": "./scripts/functions/other.lua" },

--- a/scripts/classes/preferences.lua
+++ b/scripts/classes/preferences.lua
@@ -27,6 +27,8 @@ function Preferences.show(plugin)
 		selected = Preferences.plugin.preferences.auto_overwrite,
 	}
 
+	dialog:newrow()
+
 	dialog:check {
 		id = "auto_flatten",
 		text = "Flatten layers downwards into directional layers when saving an iconstate.",

--- a/scripts/classes/preferences.lua
+++ b/scripts/classes/preferences.lua
@@ -2,60 +2,67 @@
 Preferences = {}
 
 --- Initializes the Preferences
+function Preferences.initialize(plugin)
+	-- Store the plugin object in the Preferences class
+	Preferences.plugin = plugin
 
--- Store the plugin object in the Preferences class
-Preferences.plugin = plugin
-
--- Initialize default preferences if not set
-if not Preferences.plugin.preferences.auto_overwrite then
-    Preferences.plugin.preferences.auto_overwrite = false
+	-- Initialize default preferences if not set
+	if not Preferences.plugin.preferences.auto_overwrite then
+		Preferences.plugin.preferences.auto_overwrite = false
+	end
+	if not Preferences.plugin.preferences.auto_flatten then
+		Preferences.plugin.preferences.auto_flatten = false
+	end
 end
 
 --- Shows the preferences dialog.
 function Preferences.show(plugin)
-    local dialog = Dialog {
-        title = "DMI Editor Preferences"
-    }
+	local dialog = Dialog {
+		title = "DMI Editor Preferences"
+	}
 
-    dialog:check {
-        id = "auto_overwrite",
-        text = "Overwrite source DMI files when saving an iconstate.",
-        selected = Preferences.plugin.preferences.auto_overwrite,
-    }
+	dialog:check {
+		id = "auto_overwrite",
+		text = "Overwrite source DMI files when saving an iconstate.",
+		selected = Preferences.plugin.preferences.auto_overwrite,
+	}
 
-    -- dialog:newrow()
+	dialog:check {
+		id = "auto_flatten",
+		text = "Flatten layers downwards into directional layers when saving an iconstate.",
+		selected = Preferences.plugin.preferences.auto_flatten,
+	}
 
-    -- dialog:check {
-    --     id = "auto_flatten",
-    --     text = "Flatten layers downwards into directional layers when saving an iconstate.",
-    --     selected = Preferences.plugin.preferences.auto_flatten,
-    -- }
+	dialog:button {
+		text = "&OK",
+		focus = true,
+		onclick = function()
+			Preferences.plugin.preferences.auto_overwrite = dialog.data.auto_overwrite
+			Preferences.plugin.preferences.auto_flatten = dialog.data.auto_flatten
+			dialog:close()
+		end
+	}
 
-    dialog:button {
-        text = "&OK",
-        focus = true,
-        onclick = function()
-            Preferences.plugin.preferences.auto_overwrite = dialog.data.auto_overwrite
-            -- Preferences.plugin.preferences.auto_flatten = dialog.data.auto_flatten
-            dialog:close()
-        end
-    }
+	dialog:button {
+		text = "&Cancel",
+		onclick = function()
+			dialog:close()
+		end
+	}
 
-    dialog:button {
-        text = "&Cancel",
-        onclick = function()
-            dialog:close()
-        end
-    }
-
-    dialog:show {
-        wait = false
-    }
+	dialog:show {
+		wait = false
+	}
 end
 
 --- Gets whether auto-overwrite is enabled
 function Preferences.getAutoOverwrite()
-    return Preferences.plugin.preferences.auto_overwrite or false
+	return Preferences.plugin.preferences.auto_overwrite or false
+end
+
+--- Gets whether auto-flatten is enabled
+function Preferences.getAutoFlatten()
+	return Preferences.plugin.preferences.auto_flatten or false
 end
 
 return Preferences

--- a/scripts/classes/preferences.lua
+++ b/scripts/classes/preferences.lua
@@ -11,7 +11,7 @@ function Preferences.initialize(plugin)
 		Preferences.plugin.preferences.auto_overwrite = false
 	end
 	if not Preferences.plugin.preferences.auto_flatten then
-		Preferences.plugin.preferences.auto_flatten = false
+		Preferences.plugin.preferences.auto_flatten = true
 	end
 end
 

--- a/scripts/classes/statesprite.lua
+++ b/scripts/classes/statesprite.lua
@@ -84,7 +84,7 @@ function StateSprite:save()
 		return false
 	end
 
-	-- Store original layers if we need to flatten
+	-- Store original layers if we need to auto-flatten
 	local original_layers = nil
 	if Preferences.getAutoFlatten() then
 		original_layers = {}
@@ -153,14 +153,12 @@ function StateSprite:save()
 	self.editor:repaint_states()
 	self.editor.modified = true
 
-	-- Restore original layers if we flattened
+	-- Restore original layers if we flattened by undoing all the merges
 	if original_layers then
-		-- Undo all the merges
 		while #original_layers > #self.sprite.layers do
 			app.command.Undo()
 		end
 	end
-
 
 	return true
 end

--- a/scripts/classes/statesprite.lua
+++ b/scripts/classes/statesprite.lua
@@ -90,36 +90,32 @@ function StateSprite:save()
 		original_layers = {}
 		for _, layer in ipairs(self.sprite.layers) do
 			table.insert(original_layers, layer)
-			app.alert("Found layer: " .. layer.name)
 		end
 
-		-- Start from top layer, work downwards
-		for i = 1, #self.sprite.layers do
+		-- Process each directional layer, rebuilding layer list after each merge
+		local i = 1
+		while i <= #self.sprite.layers do
 			local layer = self.sprite.layers[i]
-			if table.index_of(DIRECTION_NAMES, layer.name) == 0 then
-				app.alert("Found non-directional layer: " .. layer.name)
-				-- Find nearest directional layer above this one
-				local found_target = false
-				for j = i - 1, 1, -1 do -- (this is an inverted list)
-					if table.index_of(DIRECTION_NAMES, self.sprite.layers[j].name) > 0 then
-						app.alert("Found target directional layer: " .. self.sprite.layers[j].name)
-						-- Select the layer to merge
-						app.activeLayer = layer
-						app.alert("Set active layer to: " .. layer.name)
+			if table.index_of(DIRECTION_NAMES, layer.name) > 0 then
+				-- Look for any non-directional layers above this one
+				local merged = false
+				for j = i + 1, #self.sprite.layers do
+					local above_layer = self.sprite.layers[j]
+					if table.index_of(DIRECTION_NAMES, above_layer.name) == 0 then
+						app.activeLayer = above_layer
 						app.command.MergeDownLayer()
-						app.alert("Merged down layer")
-						found_target = true
+						merged = true
 						break
 					end
 				end
-				if not found_target then
-					app.alert("No target directional layer found below " .. layer.name)
-					break -- No more directional layers below
+				-- Don't increment i if we merged, as we need to check the same position again
+				if not merged then
+					i = i + 1
 				end
+			else
+				i = i + 1
 			end
 		end
-	else
-		app.alert("Auto-flatten is disabled")
 	end
 
 	self.state.frame_count = #self.sprite.frames

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -30,6 +30,9 @@ function init(plugin)
 		return
 	end
 
+	-- Initialize Preferences
+	Preferences.initialize(plugin)
+
 	after_listener = app.events:on("aftercommand", function(ev)
 		if ev.name == "OpenFile" then
 			if app.sprite and app.sprite.filename:ends_with(".dmi") then


### PR DESCRIPTION
Flatten layers downwards into directional layers when saving an iconstate.
This allows you to use layers in aseprite, while saving into layerless DMIs.
This works as expected with `preferences.auto_overwrite`.

![image](https://github.com/user-attachments/assets/30878a68-cd78-4abc-918b-9ee7e3eba6b9)
