### PR TITLE
Combine

### DIFF
--- a/lib/src/lua.rs
+++ b/lib/src/lua.rs
@@ -62,12 +62,13 @@ fn save_file(_: &Lua, (dmi, filename): (LuaTable, String)) -> LuaResult<LuaValue
     Ok(LuaValue::Nil)
 }
 
-fn new_state(lua: &Lua, (width, height, temp): (u32, u32, String)) -> LuaResult<LuaTable> {
+fn new_state(lua: &Lua, (width, height, temp, name): (u32, u32, String, Option<String>)) -> LuaResult<LuaTable> {
     if !Path::new(&temp).exists() {
         Err("Temp directory does not exist".to_string()).into_lua_err()?
     }
 
-    let state = State::new_blank(String::new(), width, height).to_serialized(temp)?;
+    let state_name = name.unwrap_or(String::new());
+    let state = State::new_blank(state_name, width, height).to_serialized(temp)?;
     let table = state.into_lua_table(lua)?;
 
     Ok(table)

--- a/lib/src/lua.rs
+++ b/lib/src/lua.rs
@@ -62,7 +62,10 @@ fn save_file(_: &Lua, (dmi, filename): (LuaTable, String)) -> LuaResult<LuaValue
     Ok(LuaValue::Nil)
 }
 
-fn new_state(lua: &Lua, (width, height, temp, name): (u32, u32, String, Option<String>)) -> LuaResult<LuaTable> {
+fn new_state(
+    lua: &Lua,
+    (width, height, temp, name): (u32, u32, String, Option<String>),
+) -> LuaResult<LuaTable> {
     if !Path::new(&temp).exists() {
         Err("Temp directory does not exist".to_string()).into_lua_err()?
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 			{ "path": "./scripts/classes/preferences.lua" },
 			{ "path": "./scripts/classes/editor/_editor.lua" },
 			{ "path": "./scripts/classes/editor/rendering.lua" },
+			{ "path": "./scripts/classes/editor/state_operations.lua" },
 			{ "path": "./scripts/classes/editor/state.lua" },
 			{ "path": "./scripts/classes/statesprite.lua" },
 			{ "path": "./scripts/classes/widget.lua" },

--- a/scripts/classes/editor/_editor.lua
+++ b/scripts/classes/editor/_editor.lua
@@ -28,8 +28,6 @@ Editor.__index = Editor
 
 --- @class Editor.Mouse
 --- @field position Point The current mouse position.
---- @field leftClick boolean Whether the left mouse button is pressed.
---- @field rightClick boolean Whether the right mouse button is pressed.
 
 --- Creates a new instance of the Editor class.
 --- @param title string The title of the editor.
@@ -44,13 +42,18 @@ function Editor.new(title, dmi)
 	self.focused_widget   = nil
 	self.hovering_widgets = {}
 	self.scroll           = 0
-	self.mouse            = { position = Point(0, 0), leftClick = false, rightClick = false }
+	self.mouse            = { position = Point(0, 0) }
 	self.dmi              = nil
 	self.open_sprites     = {}
 	self.widgets          = {}
+	self.selected_widgets = {}
 	self.context_widget   = nil
 	self.save_path        = nil
 	self.open_path        = is_filename and dmi --[[@as string]] or nil
+
+	self.dragging         = false
+	self.drag_start_time  = math.huge
+	self.drop_index       = nil
 
 	self.canvas_width     = 185
 	self.canvas_height    = 215
@@ -220,7 +223,10 @@ end
 
 --- Shows the editor dialog.
 function Editor:show()
-	self.dialog:show { wait = false }
+	self.dialog:show {
+		wait = false,
+		autoscrollbars=true,
+	}
 end
 
 --- Opens a DMI file and displays it in the editor.
@@ -239,6 +245,7 @@ function Editor:open_file(dmi)
 	self.scroll = 0
 	self.dmi = nil
 	self.widgets = {}
+	self.selected_widgets = {}
 	self.open_sprites = {}
 	self.save_path = nil
 

--- a/scripts/classes/editor/_editor.lua
+++ b/scripts/classes/editor/_editor.lua
@@ -13,7 +13,7 @@
 --- @field dmi Dmi The currently opened DMI file.
 --- @field open_sprites (StateSprite)[] A table containing all open sprites.
 --- @field widgets (AnyWidget)[] A table containing all state widgets.
---- @field selected_widgets (IconWidget)[] Selected icon widgets to possibly combine.
+--- @field selected_states State[] Selected icon widgets to possibly combine.
 --- @field context_widget ContextWidget|nil The state that is currently being right clicked
 --- @field beforecommand number The event object for the "beforecommand" event.
 --- @field aftercommand number The event object for the "aftercommand" event.
@@ -47,7 +47,7 @@ function Editor.new(title, dmi)
 	self.dmi              = nil
 	self.open_sprites     = {}
 	self.widgets          = {}
-	self.selected_widgets = {}
+	self.selected_states = {}
 	self.context_widget   = nil
 	self.save_path        = nil
 	self.open_path        = is_filename and dmi --[[@as string]] or nil
@@ -246,7 +246,7 @@ function Editor:open_file(dmi)
 	self.scroll = 0
 	self.dmi = nil
 	self.widgets = {}
-	self.selected_widgets = {}
+	self.selected_states = {}
 	self.open_sprites = {}
 	self.save_path = nil
 

--- a/scripts/classes/editor/_editor.lua
+++ b/scripts/classes/editor/_editor.lua
@@ -13,6 +13,7 @@
 --- @field dmi Dmi The currently opened DMI file.
 --- @field open_sprites (StateSprite)[] A table containing all open sprites.
 --- @field widgets (AnyWidget)[] A table containing all state widgets.
+--- @field selected_widgets (IconWidget)[] Selected icon widgets to possibly combine.
 --- @field context_widget ContextWidget|nil The state that is currently being right clicked
 --- @field beforecommand number The event object for the "beforecommand" event.
 --- @field aftercommand number The event object for the "aftercommand" event.

--- a/scripts/classes/editor/rendering.lua
+++ b/scripts/classes/editor/rendering.lua
@@ -375,21 +375,16 @@ function Editor:onmouseup(ev)
 			if not triggered then
 				if ev.button == MouseButton.RIGHT then
 					-- If multiple states are selected, show combine option.
+					local buttonsToAdd = {
+						{ text = "Paste", onclick = function() self:clipboard_paste_state() end },
+					}
 					if self.selected_states and #self.selected_states > 1 then
-						self.context_widget = ContextWidget.new(
-							Rectangle(ev.x, ev.y, 0, 0),
-							{
-								{ text = "Combine", onclick = function() self:combine_selected_states() end }
-							}
-						)
-					else
-						self.context_widget = ContextWidget.new(
-							Rectangle(ev.x, ev.y, 0, 0),
-							{
-								{ text = "Paste", onclick = function() self:clipboard_paste_state() end },
-							}
-						)
+						table.insert(buttonsToAdd, { text = "Combine", onclick = function() self:combine_selected_states() end })
 					end
+					self.context_widget = ContextWidget.new(
+						Rectangle(ev.x, ev.y, 0, 0),
+						buttonsToAdd
+					)
 				end
 			end
 		end

--- a/scripts/classes/editor/rendering.lua
+++ b/scripts/classes/editor/rendering.lua
@@ -397,6 +397,7 @@ function Editor:onmouseup(ev)
 					}
 					if #self.selected_states > 1 then
 						table.insert(buttonsToAdd, { text = "Combine", onclick = function() self:combine_selected_states() end })
+						table.insert(buttonsToAdd, { text = "Deselect", onclick = function() self.selected_states = {}; self:repaint() end })
 					end
 					self.context_widget = ContextWidget.new(
 						Rectangle(ev.x, ev.y, 0, 0),

--- a/scripts/classes/editor/rendering.lua
+++ b/scripts/classes/editor/rendering.lua
@@ -304,20 +304,20 @@ end
 --- Handles the mouse down event in the editor and triggers a repaint.
 --- @param ev MouseEvent The mouse event object.
 function Editor:onmousedown(ev)
-	-- Add Control-click selection
-	if ev.ctrlKey then
-		for _, widget in ipairs(self.widgets) do
-			if widget.type == "IconWidget" and widget.bounds:contains(Point(ev.x, ev.y)) then
-				self:toggle_state_selection(widget)
-				self:repaint()
-				return
-			end
-		end
-	end
-
 	if ev.button == MouseButton.LEFT then
 		self.mouse.leftClick = true
 		self.focused_widget = nil
+
+		-- Selection mode
+		if ev.ctrlKey then
+			for _, widget in ipairs(self.widgets) do
+				if widget.type == "IconWidget" and widget.bounds:contains(Point(ev.x, ev.y)) then
+					self:toggle_state_selection(widget)
+					self:repaint()
+					return
+				end
+			end
+		end
 
 		-- Only start drag if we're not clicking on a context menu
 		if not self.context_widget then

--- a/scripts/classes/editor/rendering.lua
+++ b/scripts/classes/editor/rendering.lua
@@ -321,13 +321,18 @@ function Editor:onmousedown(ev)
 
 		-- Only start drag if we're not clicking on a context menu
 		if not self.context_widget then
-			-- Start potential drag
+			local clickedState = false
 			for _, widget in ipairs(self.widgets) do
 				if widget.type == "IconWidget" and widget.bounds:contains(Point(ev.x, ev.y)) then
 					self.drag_widget = widget
 					self.drag_start_time = os.clock()
+					clickedState = true
 					break
 				end
+			end
+			-- If click did not hit any state widget, clear selected states.
+			if not clickedState then
+				self.selected_states = {}
 			end
 		end
 	elseif ev.button == MouseButton.RIGHT then

--- a/scripts/classes/editor/rendering.lua
+++ b/scripts/classes/editor/rendering.lua
@@ -239,9 +239,9 @@ function Editor:repaint_states()
 				bounds,
 				icon,
 				function() self:open_state(state) end,
-				function(ev) self:state_context(state, ev) end
+				function(ev) self:state_context(state, ev) end,
+				state
 			)
-			iconWidget.state = state
 			table.insert(self.widgets, iconWidget)
 
 			table.insert(self.widgets, TextWidget.new(

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -134,7 +134,7 @@ function Editor:state_context(state, ev)
 		{ text = "Remove",     onclick = function() self:remove_state(state) end },
 		{ text = "Split",      onclick = function() self:split_state(state) end },
 	}
-	if self.selected_widgets and #self.selected_widgets > 1 then
+	if #self.selected_widgets > 1 then
 		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })
 	end
 	self.context_widget = ContextWidget.new(

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -136,7 +136,16 @@ function Editor:state_context(state, ev)
 	}
 	if #self.selected_states > 1 then
 		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })
-		table.insert(buttons, { text = "Deselect", onclick = function() self.selected_states = {}; self:repaint() end })
+		table.insert(buttons, {
+			text = "Deselect",
+			onclick = function()
+				local i = table.index_of(self.selected_states, state)
+				if i ~= 0 then
+					table.remove(self.selected_states, i)
+				end
+				self:repaint()
+			end
+		})
 	end
 	self.context_widget = ContextWidget.new(
 		Rectangle(ev.x, ev.y, 0, 0),

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -133,6 +133,15 @@ function Editor:state_context(state, ev)
 		{ text = "Copy",       onclick = function() self:clipboard_copy_state(state) end },
 		{ text = "Remove",     onclick = function() self:remove_state(state) end },
 		{ text = "Split",      onclick = function() self:split_state(state) end },
+		{ text = "Select",
+			onclick = function()
+				local i = table.index_of(self.selected_states, state)
+				if i == 0 then
+					table.insert(self.selected_states, state)
+				end
+				self:repaint()
+			end
+		},
 	}
 	if #self.selected_states > 1 then
 		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -127,15 +127,19 @@ end
 --- @param state State The state to be opened.
 --- @param ev MouseEvent The mouse event object.
 function Editor:state_context(state, ev)
+	local buttons = {
+		{ text = "Properties", onclick = function() self:state_properties(state) end },
+		{ text = "Open",       onclick = function() self:open_state(state) end },
+		{ text = "Copy",       onclick = function() self:clipboard_copy_state(state) end },
+		{ text = "Remove",     onclick = function() self:remove_state(state) end },
+		{ text = "Split",      onclick = function() self:split_state(state) end },
+	}
+	if self.selected_states and #self.selected_states > 1 then
+		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })
+	end
 	self.context_widget = ContextWidget.new(
 		Rectangle(ev.x, ev.y, 0, 0),
-		{
-			{ text = "Properties", onclick = function() self:state_properties(state) end },
-			{ text = "Open",       onclick = function() self:open_state(state) end },
-			{ text = "Copy",       onclick = function() self:clipboard_copy_state(state) end },
-			{ text = "Remove",     onclick = function() self:remove_state(state) end },
-			{ text = "Split",      onclick = function() self:split_state(state) end },
-		}
+		buttons
 	)
 	self:repaint()
 end
@@ -1018,83 +1022,4 @@ function Editor:reload_open_states()
 	for _, state in ipairs(open_states) do
 		self:open_state(state)
 	end
-end
-
---- Splits a multi-directional state into individual states, one for each direction.
---- @param state State The state to be split.
-function Editor:split_state(state)
-	if not self.dmi then return end
-	if state.dirs == 1 then
-		app.alert { title = "Warning", text = "Cannot split a state with only one direction" }
-		return
-	end
-
-	-- Check if state is open and modified
-	for _, state_sprite in ipairs(self.open_sprites) do
-		if state_sprite.state == state then
-			if state_sprite.sprite.isModified then
-				app.alert { title = self.title, text = "Save the open sprite first" }
-				return
-			end
-			break
-		end
-	end
-
-	local original_name = state.name
-	local direction_names = {
-		[4] = { "S", "N", "E", "W" },
-		[8] = { "S", "N", "E", "W", "SE", "SW", "NE", "NW" }
-	}
-
-	-- Create a new state for each direction
-	for i = 1, state.dirs do
-		local new_state, error = libdmi.new_state(self.dmi.width, self.dmi.height, self.dmi.temp)
-		if error then
-			app.alert { title = "Error", text = { "Failed to create new state", error } }
-			return
-		end
-
-		if not new_state then
-			app.alert { title = "Error", text = "Failed to create new state" }
-			return
-		end
-
-		-- Set the new state properties
-		new_state.name = original_name .. " - " .. direction_names[state.dirs][i]
-		new_state.dirs = 1
-		new_state.loop = state.loop
-		new_state.rewind = state.rewind
-		new_state.movement = state.movement
-		new_state.delays = table.clone(state.delays)
-
-		-- Copy the image data for this direction
-		local frames_per_dir = state.frame_count
-		local start_frame = (i - 1) * frames_per_dir
-
-		for frame = 1, frames_per_dir do
-			local src_path = app.fs.joinPath(self.dmi.temp, state.frame_key .. "." .. tostring(start_frame + frame - 1) .. ".bytes")
-			local dst_path = app.fs.joinPath(self.dmi.temp, new_state.frame_key .. "." .. tostring(frame - 1) .. ".bytes")
-
-			-- Copy the image file
-			local src_file = io.open(src_path, "rb")
-			if src_file then
-				local content = src_file:read("*all")
-				src_file:close()
-
-				local dst_file = io.open(dst_path, "wb")
-				if dst_file then
-					dst_file:write(content)
-					dst_file:close()
-				end
-			end
-		end
-
-		table.insert(self.dmi.states, new_state)
-		self.image_cache:load_state(self.dmi, new_state)
-	end
-
-	-- Mark as modified and remove the original state
-	self.modified = true
-	self:remove_state(state)
-	self:repaint_states()
 end

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -134,7 +134,7 @@ function Editor:state_context(state, ev)
 		{ text = "Remove",     onclick = function() self:remove_state(state) end },
 		{ text = "Split",      onclick = function() self:split_state(state) end },
 	}
-	if #self.selected_widgets > 1 then
+	if #self.selected_states > 1 then
 		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })
 	end
 	self.context_widget = ContextWidget.new(

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -134,7 +134,7 @@ function Editor:state_context(state, ev)
 		{ text = "Remove",     onclick = function() self:remove_state(state) end },
 		{ text = "Split",      onclick = function() self:split_state(state) end },
 	}
-	if self.selected_states and #self.selected_states > 1 then
+	if self.selected_widgets and #self.selected_widgets > 1 then
 		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })
 	end
 	self.context_widget = ContextWidget.new(

--- a/scripts/classes/editor/state.lua
+++ b/scripts/classes/editor/state.lua
@@ -136,6 +136,7 @@ function Editor:state_context(state, ev)
 	}
 	if #self.selected_states > 1 then
 		table.insert(buttons, { text = "Combine", onclick = function() self:combine_selected_states() end })
+		table.insert(buttons, { text = "Deselect", onclick = function() self.selected_states = {}; self:repaint() end })
 	end
 	self.context_widget = ContextWidget.new(
 		Rectangle(ev.x, ev.y, 0, 0),

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -79,7 +79,7 @@ end
 
 --- Combines multiple selected states into one state.
 function Editor:combine_selected_states()
-	if not self.dmi or not self.selected_widgets or #self.selected_widgets < 2 then
+	if not self.dmi or #self.selected_widgets < 2 then
 		app.alert { title = self.title, text = "Select at least two states to combine." }
 		return
 	end

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -82,7 +82,7 @@ end
 
 --- Combines multiple selected states into one state.
 function Editor:combine_selected_states()
-	if not self.dmi or not self.selected_states or #self.selected_states < 2 then
+	if not self.dmi or not self.selected_widgets or #self.selected_widgets < 2 then
 		app.alert { title = self.title, text = "Select at least two states to combine." }
 		return
 	end
@@ -129,9 +129,10 @@ function Editor:getCombinedDefaultName()
 		end
 		return a:sub(1, i - 1)
 	end
-	local commonBase = normalize(self.selected_states[1].name)
-	for i = 2, #self.selected_states do
-		commonBase = commonPrefix(commonBase, normalize(self.selected_states[i].name))
+
+	local commonBase = normalize(self.selected_widgets[1].state.name)
+	for i = 2, #self.selected_widgets do
+		commonBase = commonPrefix(commonBase, normalize(self.selected_widgets[i].state.name))
 		if commonBase == "" then break end
 	end
 	if commonBase and #commonBase > 2 then -- <3 char names are not useful
@@ -152,8 +153,8 @@ function Editor:performCombineStates(combinedName, combineType)
 	-- Reorder selected states based on DMI order
 	local sortedStates = {}
 	for _, state in ipairs(self.dmi.states) do
-		for _, sel in ipairs(self.selected_states) do
-			if state == sel then
+		for _, selWidget in ipairs(self.selected_widgets) do
+			if state == selWidget.state then
 				table.insert(sortedStates, state)
 				break
 			end
@@ -182,9 +183,8 @@ function Editor:performCombineStates(combinedName, combineType)
 	table.insert(self.dmi.states, combined_state)
 	self.image_cache:load_state(self.dmi, combined_state)
 	self.modified = true
+	self.selected_widgets = {}
 	self:repaint_states()
-	self.selected_states = {}
-	app.alert { title = self.title, text = "States have been combined." }
 end
 
 function Editor:combine1direction(combined_state, sortedStates)
@@ -199,3 +199,10 @@ function Editor:combine1direction(combined_state, sortedStates)
 	end
 	return true
 end
+
+function printtable(table, indent)
+	print(tostring(table) .. '\n')
+	for index, value in pairs(table) do
+	  print('    ' .. tostring(index) .. ' : ' .. tostring(value) .. '\n')
+	end
+  end

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -79,7 +79,7 @@ end
 
 --- Combines multiple selected states into one state.
 function Editor:combine_selected_states()
-	if not self.dmi or #self.selected_widgets < 2 then
+	if not self.dmi or #self.selected_states < 2 then
 		app.alert { title = self.title, text = "Select at least two states to combine." }
 		return
 	end
@@ -94,6 +94,9 @@ function Editor:combine_selected_states()
 		label = "Combine Method:",
 		option = COMBINE_TYPES.onedir,
 		options = { COMBINE_TYPES.onedir },
+	}
+	dialog:label {
+		text = "Note: This does not work for combining animated states currently.",
 	}
 	dialog:button {
 		text = "&OK",
@@ -127,9 +130,9 @@ function Editor:getCombinedDefaultName()
 		return a:sub(1, i - 1)
 	end
 
-	local commonBase = normalize(self.selected_widgets[1].iconstate.name)
-	for i = 2, #self.selected_widgets do
-		commonBase = commonPrefix(commonBase, normalize(self.selected_widgets[i].iconstate.name))
+	local commonBase = normalize(self.selected_states[1].name)
+	for i = 2, #self.selected_states do
+		commonBase = commonPrefix(commonBase, normalize(self.selected_states[i].name))
 		if commonBase == "" then break end
 	end
 	if commonBase and #commonBase > 2 then -- < 3 char names are not useful
@@ -151,8 +154,8 @@ function Editor:performCombineStates(combinedName, combineType)
 	-- Selected iconstates based on DMI order
 	local sortedStates = {}
 	for _, state in ipairs(self.dmi.states) do
-		for _, selWidget in ipairs(self.selected_widgets) do
-			if state == selWidget.iconstate then
+		for _, selState in ipairs(self.selected_states) do
+			if state == selState then
 				table.insert(sortedStates, state)
 				break
 			end
@@ -170,7 +173,7 @@ function Editor:performCombineStates(combinedName, combineType)
 	table.insert(self.dmi.states, combined_state)
 	self.image_cache:load_state(self.dmi, combined_state)
 	self.modified = true
-	self.selected_widgets = {}
+	self.selected_states = {}
 	self:repaint_states()
 end
 

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -95,6 +95,12 @@ function Editor:combine_selected_states()
 		option = COMBINE_TYPES.onedir,
 		options = { COMBINE_TYPES.onedir },
 	}
+	dialog:combobox {
+		id = "frame_sel_type",
+		label = "Frame Selection:",
+		option = FRAME_SEL_TYPES.all_seq,
+		options = { FRAME_SEL_TYPES.all_seq, FRAME_SEL_TYPES.first_only,  },
+	}
 	dialog:label {
 		text = "Note: This does not work for combining animated states currently.",
 	}
@@ -104,8 +110,9 @@ function Editor:combine_selected_states()
 		onclick = function()
 			local combinedName = dialog.data.combined_name or "Combined"
 			local combineType = dialog.data.combine_type or COMBINE_TYPES.onedir
+			local frameSelType = dialog.data.frame_sel_type or FRAME_SEL_TYPES.all_seq
 			dialog:close()
-			self:performCombineStates(combinedName, combineType)
+			self:performCombineStates(combinedName, combineType, frameSelType)
 		end
 	}
 	dialog:button {
@@ -144,7 +151,7 @@ end
 
 --- Combines the selected states into one state, based off of the selected combination type.
 --- @param combinedName string The name for the combined state.
-function Editor:performCombineStates(combinedName, combineType)
+function Editor:performCombineStates(combinedName, combineType, frameSelType)
 	local combined_state, error = libdmi.new_state(self.dmi.width, self.dmi.height, self.dmi.temp, combinedName)
 	if error or not combined_state then
 		app.alert { title = "Error", text = { "Failed to create combined state", error } }
@@ -164,11 +171,9 @@ function Editor:performCombineStates(combinedName, combineType)
 
 	combined_state.name = combinedName
 	if combineType == COMBINE_TYPES.onedir then
-		if not self:combine1direction(combined_state, sortedStates) then
+		if not self:combine1direction(combined_state, sortedStates, frameSelType) then
 			return
 		end
-	else
-		-- Future expansion placeholder for other combine types.
 	end
 	table.insert(self.dmi.states, combined_state)
 	self.image_cache:load_state(self.dmi, combined_state)

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -1,0 +1,155 @@
+-- This file defines split_state and combine_selected_states for the Editor.
+-- Assumes global Editor is already defined.
+
+--- Splits a multi-directional state into individual states, one for each direction.
+--- @param state State The state to be split.
+function Editor:split_state(state)
+	if not self.dmi then return end
+	if state.dirs == 1 then
+		app.alert { title = "Warning", text = "Cannot split a state with only one direction" }
+		return
+	end
+
+	-- Check if state is open and modified
+	for _, state_sprite in ipairs(self.open_sprites) do
+		if state_sprite.state == state then
+			if state_sprite.sprite.isModified then
+				app.alert { title = self.title, text = "Save the open sprite first" }
+				return
+			end
+			break
+		end
+	end
+
+	local original_name = state.name
+	local direction_names = {
+		[4] = { "S", "N", "E", "W" },
+		[8] = { "S", "N", "E", "W", "SE", "SW", "NE", "NW" }
+	}
+
+	-- Create a new state for each direction
+	for i = 1, state.dirs do
+		local new_state, error = libdmi.new_state(self.dmi.width, self.dmi.height, self.dmi.temp)
+		if error then
+			app.alert { title = "Error", text = { "Failed to create new state", error } }
+			return
+		end
+
+		if not new_state then
+			app.alert { title = "Error", text = "Failed to create new state" }
+			return
+		end
+
+		-- Set the new state properties
+		new_state.name = original_name .. " - " .. direction_names[state.dirs][i]
+		new_state.dirs = 1
+		new_state.loop = state.loop
+		new_state.rewind = state.rewind
+		new_state.movement = state.movement
+		new_state.delays = table.clone(state.delays)
+
+		-- Copy the image data for this direction
+		local frames_per_dir = state.frame_count
+		local start_frame = (i - 1) * frames_per_dir
+
+		for frame = 1, frames_per_dir do
+			local src_path = app.fs.joinPath(self.dmi.temp, state.frame_key .. "." .. tostring(start_frame + frame - 1) .. ".bytes")
+			local dst_path = app.fs.joinPath(self.dmi.temp, new_state.frame_key .. "." .. tostring(frame - 1) .. ".bytes")
+
+			-- Copy the image file
+			local src_file = io.open(src_path, "rb")
+			if src_file then
+				local content = src_file:read("*all")
+				src_file:close()
+
+				local dst_file = io.open(dst_path, "wb")
+				if dst_file then
+					dst_file:write(content)
+					dst_file:close()
+				end
+			end
+		end
+
+		table.insert(self.dmi.states, new_state)
+		self.image_cache:load_state(self.dmi, new_state)
+	end
+
+	-- Mark as modified and remove the original state
+	self.modified = true
+	self:remove_state(state)
+	self:repaint_states()
+end
+
+--- Combines multiple selected states into one state.
+function Editor:combine_selected_states()
+	if not self.dmi or not self.selected_states or #self.selected_states < 2 then
+		app.alert { title = self.title, text = "Select at least two states to combine." }
+		return
+	end
+	local combined_state, error = libdmi.new_state(self.dmi.width, self.dmi.height, self.dmi.temp)
+	if error or (not combined_state) then
+		app.alert { title = "Error", text = { "Failed to create combined state", error } }
+		return
+	end
+
+	-- Normalize a string by removing dashes, underscores, and numbers.
+	local function normalize(s)
+		return s:gsub("[-_%d]", "")
+	end
+
+	-- Compute longest common prefix between two strings.
+	local function commonPrefix(a, b)
+		local len = math.min(#a, #b)
+		local prefix = ""
+		for i = 1, len do
+			if a:sub(i, i) == b:sub(i, i) then
+				prefix = prefix .. a:sub(i, i)
+			else
+				break
+			end
+		end
+		return prefix
+	end
+
+	local commonBase = normalize(self.selected_states[1].name)
+	for i = 2, #self.selected_states do
+		commonBase = commonPrefix(commonBase, normalize(self.selected_states[i].name))
+		if commonBase == "" then break end
+	end
+	if commonBase and #commonBase > 0 then
+		combined_state.name = commonBase
+	else
+		combined_state.name = "Combined"
+	end
+
+	-- Reorder selected states in the order they appear in the dmi.
+	local sortedStates = {}
+	for _, state in ipairs(self.dmi.states) do
+		for _, sel in ipairs(self.selected_states) do
+			if state == sel then
+				table.insert(sortedStates, state)
+				break
+			end
+		end
+	end
+
+	combined_state.frame_count = #sortedStates
+	combined_state.delays = {}
+	-- For each state in sorted order, copy its preview image as a new frame.
+	for i, state in ipairs(sortedStates) do
+		local preview = self.image_cache:get(state.frame_key)
+		if not preview then
+			app.alert { title = "Error", text = "Preview image missing for state: " .. (state.name or "unknown") }
+			return
+		end
+		save_image_bytes(preview, app.fs.joinPath(self.dmi.temp, combined_state.frame_key .. "." .. (i - 1) .. ".bytes"))
+		combined_state.delays[i] = 100  -- set default delay
+	end
+	table.insert(self.dmi.states, combined_state)
+	self.image_cache:load_state(self.dmi, combined_state)
+	self.modified = true
+	self:repaint_states()
+	-- Clear selection after combining.
+	self.selected_states = {}
+	app.alert { title = self.title, text = "States have been combined." }
+end

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -168,17 +168,6 @@ function Editor:performCombineStates(combinedName, combineType)
 		end
 	else
 		-- Future expansion placeholder for other combine types.
-		combined_state.frame_count = #sortedStates
-		combined_state.delays = {}
-		for i, state in ipairs(sortedStates) do
-			local preview = self.image_cache:get(state.frame_key)
-			if not preview then
-				app.alert { title = "Error", text = "Preview image missing for state: " .. (state.name or "unknown") }
-				return
-			end
-			save_image_bytes(preview, app.fs.joinPath(self.dmi.temp, combined_state.frame_key .. "." .. (i - 1) .. ".bytes"))
-			combined_state.delays[i] = 100  -- set default delay
-		end
 	end
 	table.insert(self.dmi.states, combined_state)
 	self.image_cache:load_state(self.dmi, combined_state)

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -199,10 +199,3 @@ function Editor:combine1direction(combined_state, sortedStates)
 	end
 	return true
 end
-
-function printtable(table, indent)
-	print(tostring(table) .. '\n')
-	for index, value in pairs(table) do
-	  print('    ' .. tostring(index) .. ' : ' .. tostring(value) .. '\n')
-	end
-  end

--- a/scripts/classes/editor/state_operations.lua
+++ b/scripts/classes/editor/state_operations.lua
@@ -1,6 +1,3 @@
--- This file defines split_state and combine_selected_states for the Editor.
--- Assumes global Editor is already defined.
-
 --- Splits a multi-directional state into individual states, one for each direction.
 --- @param state State The state to be split.
 function Editor:split_state(state)
@@ -117,7 +114,7 @@ function Editor:combine_selected_states()
 	dialog:show()
 end
 
--- Add a new function to compute the default combined name
+--- Gets the default name for the combined state based on the selected states.
 function Editor:getCombinedDefaultName()
 	local function normalize(s) -- Remove _ and - and numbers
 		return s:gsub("[-_%d]", "")
@@ -135,14 +132,15 @@ function Editor:getCombinedDefaultName()
 		commonBase = commonPrefix(commonBase, normalize(self.selected_widgets[i].state.name))
 		if commonBase == "" then break end
 	end
-	if commonBase and #commonBase > 2 then -- <3 char names are not useful
+	if commonBase and #commonBase > 2 then -- < 3 char names are not useful
 		return commonBase
 	else
 		return "Combined"
 	end
 end
 
--- Modified performCombineStates function to use combine1direction
+--- Combines the selected states into one state, based off of the selected combination type.
+--- @param combinedName string The name for the combined state.
 function Editor:performCombineStates(combinedName, combineType)
 	local combined_state, error = libdmi.new_state(self.dmi.width, self.dmi.height, self.dmi.temp)
 	if error or not combined_state then

--- a/scripts/classes/statesprite.lua
+++ b/scripts/classes/statesprite.lua
@@ -94,9 +94,17 @@ function StateSprite:save()
 		return false
 	end
 
-	-- Store original layers if we need to auto-flatten (only if multiple layers exist)
+	-- Store original layers if we need to auto-flatten
+	-- And only if there's layers that aren't the magic directional names
 	local original_layers = nil
-	if Preferences.getAutoFlatten() and #self.sprite.layers > 1 then
+	local hasNonDirectional = false
+	for _, layer in ipairs(self.sprite.layers) do
+		if table.index_of(DIRECTION_NAMES, layer.name) == 0 then
+			hasNonDirectional = true
+			break
+		end
+	end
+	if Preferences.getAutoFlatten() and hasNonDirectional then
 		original_layers = {}
 		for _, layer in ipairs(self.sprite.layers) do
 			table.insert(original_layers, layer)

--- a/scripts/classes/statesprite.lua
+++ b/scripts/classes/statesprite.lua
@@ -94,9 +94,9 @@ function StateSprite:save()
 		return false
 	end
 
-	-- Store original layers if we need to auto-flatten
+	-- Store original layers if we need to auto-flatten (only if multiple layers exist)
 	local original_layers = nil
-	if Preferences.getAutoFlatten() then
+	if Preferences.getAutoFlatten() and #self.sprite.layers > 1 then
 		original_layers = {}
 		for _, layer in ipairs(self.sprite.layers) do
 			table.insert(original_layers, layer)
@@ -169,7 +169,7 @@ function StateSprite:save()
 	self.editor.modified = true
 
 	-- Restore original layers if we flattened by undoing the transaction from above
-	if Preferences.getAutoFlatten() then
+	if original_layers then
 		app.command.Undo()
 	end
 

--- a/scripts/classes/widget.lua
+++ b/scripts/classes/widget.lua
@@ -19,6 +19,7 @@
 --- @field icon Image The icon of the widget.
 --- @field onleftclick MouseFunction|nil The onleftclick function of the widget.
 --- @field onrightclick MouseFunction|nil The onrightclick function of the widget.
+--- @field iconstate State|nil The iconstate of the widget (optional).
 IconWidget = { type = "IconWidget" }
 IconWidget.__index = IconWidget
 
@@ -28,8 +29,9 @@ IconWidget.__index = IconWidget
 --- @param icon Image The icon of the widget.
 --- @param onleftclick MouseFunction|nil The function to be called when the widget is clicked (optional).
 --- @param onrightclick MouseFunction|nil The function to be called when the widget is right clicked (optional).
+--- @param iconstate State an associated iconstate (optional)
 --- @return IconWidget widget The newly created widget.
-function IconWidget.new(editor, bounds, icon, onleftclick, onrightclick)
+function IconWidget.new(editor, bounds, icon, onleftclick, onrightclick, iconstate)
 	local self = setmetatable({}, IconWidget)
 
 	self.editor = editor
@@ -37,6 +39,7 @@ function IconWidget.new(editor, bounds, icon, onleftclick, onrightclick)
 	self.icon = icon
 	self.onleftclick = onleftclick or nil
 	self.onrightclick = onrightclick or nil
+	self.iconstate = iconstate or nil
 
 	return self
 end

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -17,3 +17,8 @@ COMMON_STATE = {
 COMBINE_TYPES = {
 	onedir = "1 direction",
 }
+
+FRAME_SEL_TYPES = {
+	first_only = "First frame only",
+	all_seq = "All frames",
+}

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -16,6 +16,7 @@ COMMON_STATE = {
 
 COMBINE_TYPES = {
 	onedir = "1 direction",
+	alldirs = "All directions",
 }
 
 FRAME_SEL_TYPES = {

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -10,6 +10,10 @@ TEMP_DIR = app.fs.joinPath(app.fs.tempPath, TEMP_NAME)
 COMMON_STATE = {
 	normal = { part = "sunken_normal", color = "button_normal_text" },
 	hot = { part = "sunken_focused", color = "button_hot_text" },
-	focused = { part = "sunken_mini_focused", color = "button_normal_text" },
+	focused = { part = "sunken_focused", color = "button_normal_text" },
 	selected = { part = "sunken_mini_focused", color = "button_normal_text" },
 } --[[@as WidgetState]]
+
+COMBINE_TYPES = {
+	onedir = "1 direction",
+}

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -10,4 +10,6 @@ TEMP_DIR = app.fs.joinPath(app.fs.tempPath, TEMP_NAME)
 COMMON_STATE = {
 	normal = { part = "sunken_normal", color = "button_normal_text" },
 	hot = { part = "sunken_focused", color = "button_hot_text" },
+	focused = { part = "sunken_mini_focused", color = "button_normal_text" },
+	selected = { part = "sunken_mini_focused", color = "button_normal_text" },
 } --[[@as WidgetState]]

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -14,11 +14,13 @@ COMMON_STATE = {
 	selected = { part = "sunken_mini_focused", color = "button_normal_text" },
 } --[[@as WidgetState]]
 
+--- @alias CombineType "1 direction"|"All directions"
 COMBINE_TYPES = {
 	onedir = "1 direction",
 	alldirs = "All directions",
 }
 
+--- @alias FrameSelType "First frame only"|"All frames"
 FRAME_SEL_TYPES = {
 	first_only = "First frame only",
 	all_seq = "All frames",

--- a/scripts/types.lua
+++ b/scripts/types.lua
@@ -198,6 +198,7 @@ end
 
 ------------------- ENUMS -------------------
 
+--- @enum ColorMode
 ColorMode = {
 	RGB = 1,
 	GRAY = 2,
@@ -205,7 +206,9 @@ ColorMode = {
 	TILEMAP = 4,
 }
 
+--- @enum MouseButton
 MouseButton = {
+	NONE = 0,
 	LEFT = 1,
 	MIDDLE = 2,
 	RIGHT = 3,
@@ -213,6 +216,7 @@ MouseButton = {
 	X2 = 5,
 }
 
+--- @enum BlendMode
 BlendMode = {
 	NORMAL = 0,
 	SRC = 1,
@@ -236,6 +240,7 @@ BlendMode = {
 	DIVIDE = 19,
 }
 
+--- @enum WebSocketMessageType
 WebSocketMessageType = {
 	TEXT = "TEXT",
 	BINARY = "BINARY",
@@ -746,55 +751,11 @@ WebSocketMessageType = {
 
 --- @alias PixelColor number
 
---- @class MouseButton
---- @field LEFT number
---- @field MIDDLE number
---- @field RIGHT number
---- @field X1 number
---- @field X2 number
-
---- @alias ColorMode
----| 0
----| 1
----| 2
----| 3
-
---- @alias BlendMode
----| 0
----| 1
----| 2
----| 3
----| 4
----| 5
----| 6
----| 7
----| 8
----| 9
----| 10
----| 11
----| 12
----| 13
----| 14
----| 15
----| 16
----| 17
----| 18
----| 19
-
 --- @alias AniDir
 ---| 0
 ---| 1
 ---| 2
 ---| 3
-
---- @alias WebSocketMessageType
----| 'TEXT'
----| 'BINARY'
----| 'OPEN'
----| 'CLOSE'
----| 'PING'
----| 'PONG'
----| 'FRAGMENT'
 
 --- @class LibDmi: table
 --- @field new_file fun(name: string, width: number, height: number, temp: string): Dmi?, string? Creates a new DMI file. If fails, returns nil and an error message.

--- a/scripts/types.lua
+++ b/scripts/types.lua
@@ -761,7 +761,7 @@ WebSocketMessageType = {
 --- @field new_file fun(name: string, width: number, height: number, temp: string): Dmi?, string? Creates a new DMI file. If fails, returns nil and an error message.
 --- @field open_file fun(path: string, temp: string): Dmi?, string? Opens a DMI file. If fails, returns nil and an error message.
 --- @field save_file fun(dmi: Dmi, filename: string): nil, string? Saves the DMI file. If fails, returns an error message.
---- @field new_state fun(width: number, height: number, temp: string): State?, string? Creates a new state. If fails, returns nil and an error message.
+--- @field new_state fun(width: number, height: number, temp: string, name?: string): State?, string? Creates a new state. If fails, returns nil and an error message.
 --- @field copy_state fun(state: State, temp: string): nil, string? Copies the state to the clipboard. If fails, returns an error message.
 --- @field paste_state fun(width: number, height: number, temp: string): State?, string? Pastes the state from the clipboard. If fails, returns nil and an error message.
 --- @field resize fun(dmi: Dmi, width: number, height: number, medhod: string): nil, string? Resizes the DMI file. If fails, returns an error message.


### PR DESCRIPTION
Adds a new requested '**Combine**' feature, allowing you to combine multiple selected icon states into one combination.
You can specify to keep all directions and frames, or just the first one of each.

You can (de)select states to combine via <kbd>Ctrl + Click</kbd>, just like in DreamMaker.
You can use <kbd>Shift + Ctrl + Click</kbd> to mass-select.

## Example

![image](https://github.com/user-attachments/assets/75f84880-c37f-4438-8bc0-bd88b34faf5e)

![Aseprite_3TS7T11q5K](https://github.com/user-attachments/assets/3e7b7a48-d151-4d7e-946a-12b0ce4a1520)


