### PR TITLE
Update popup opens releases page

### DIFF
--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -273,7 +273,7 @@ function update_popup()
 		focus = true,
 		text = "&OK",
 		onclick = function()
-			libdmi.open_repo("issues")
+			libdmi.open_repo("releases")
 			dialog:close()
 		end,
 	}


### PR DESCRIPTION
The update popup opens the issues page right now, it should open releases instead