### PR TITLE
Explicitly link to liblua on macos/linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,29 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+
+      - name: Install lua-dev
+        run: sudo apt-get update && sudo apt-get install -y liblua5.4-dev pkg-config
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: './lib -> target'
+
       - name: Run rustfmt
         working-directory: lib
         run: |
           cargo fmt -- --check
+
       - name: Run clippy
         working-directory: lib
         run: |
           cargo clippy --locked -- -D warnings
+
       - name: Check release version
         if: startsWith(github.ref, 'refs/tags/v')
         working-directory: lib
@@ -66,41 +74,59 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build - ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+
+      - name: Install lua-dev (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y liblua5.4-dev pkg-config
+
+      - name: Install lua-dev (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install lua@5.4 pkg-config
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.rust-target }}
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: './lib -> target'
+
       - name: Run cargo tests
         working-directory: lib
         run: |
           cargo test --target ${{ matrix.rust-target }} --locked --test dmi
+
       - name: Run cargo build
         working-directory: lib
         run: |
           cargo build --target ${{ matrix.rust-target }} --locked --release
+
       - name: Run build script
         run: |
           python tools/build.py --ci ${{ matrix.rust-target }}
+
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}
           path: |
             dist/*
           if-no-files-found: error
+
   release:
     needs: build
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+
       - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
+
       - uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest, macos-latest ]
         include:
           - os: windows-latest
             name: Windows
@@ -68,9 +67,12 @@ jobs:
           - os: ubuntu-latest
             name: Linux
             rust-target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            name: macOS
+          - os: macos-26-intel
+            name: macOS Intel
             rust-target: x86_64-apple-darwin
+          - os: macos-latest
+            name: macOS ARM64
+            rust-target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     name: Build - ${{ matrix.name }}
     steps:
@@ -89,7 +91,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.rust-target }}
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: './lib -> target'
@@ -115,8 +116,39 @@ jobs:
             dist/*
           if-no-files-found: error
 
-  release:
+  macos-universal:
     needs: build
+    name: Build - macOS Universal
+    runs-on: macos-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: macOS Intel
+          path: intel
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: macOS ARM64
+          path: arm64
+
+      - name: Create universal extension
+        run: |
+          mkdir intel-unpacked arm64-unpacked universal dist
+          unzip "$(find intel -name '*.aseprite-extension' -print -quit)" -d intel-unpacked
+          unzip "$(find arm64 -name '*.aseprite-extension' -print -quit)" -d arm64-unpacked
+          cp -R arm64-unpacked/. universal/
+          lipo -create intel-unpacked/libdmi.dylib arm64-unpacked/libdmi.dylib -output universal/libdmi.dylib
+          (cd universal && zip -r ../dist/aseprite-dmi-macos.zip .)
+          cp dist/aseprite-dmi-macos.zip dist/aseprite-dmi-macos.aseprite-extension
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: macOS Universal
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    needs: [build, macos-universal]
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
@@ -125,8 +157,18 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
+          name: Windows
           path: dist
-          merge-multiple: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: Linux
+          path: dist
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: macOS Universal
+          path: dist
 
       - uses: softprops/action-gh-release@v3
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install lua@5.4 pkg-config
+          echo "PKG_CONFIG_PATH=$(brew --prefix lua@5.4)/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Not supported on Steam builds due to dynamic library issues. Running the Windows
 
 -	[Rust](https://www.rust-lang.org/)
 -	[Python](https://www.python.org/)
+-	Linux (Debian/Ubuntu): `sudo apt install liblua5.4-dev pkg-config`
+-	macOS (Homebrew): `brew install lua@5.4 pkg-config`
 
-To build the project, run `tools/build.py` Python script.
+To build the project, run the `tools/build.py` Python script.
 
 ### Releasing
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Not supported on Steam builds due to dynamic library issues. Running the Windows
 
 To build the project, run the `tools/build.py` Python script.
 
+On macOS, you'll need to set up pkg-config: `PKG_CONFIG_PATH="$(brew --prefix lua@5.4)/lib/pkgconfig" python tools/build.py`
+
 ### Releasing
 
 Push a git tag like `v1.0.8`, after changing the Cargo.toml and package.json files.

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "mlua",
  "native-dialog",
  "open",
+ "pkg-config",
  "png",
  "reqwest",
  "sanitize-filename",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1.0"
 sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 thiserror = "2.0"
 open = "5.4"
+
+[target.'cfg(not(windows))'.build-dependencies]
+pkg-config = "0.3"

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -1,3 +1,4 @@
+#[cfg(not(windows))]
 extern crate pkg_config;
 
 fn main() {

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -1,0 +1,9 @@
+extern crate pkg_config;
+
+fn main() {
+    #[cfg(not(windows))]
+    pkg_config::Config::new()
+        .atleast_version("5.4")
+        .probe("lua")
+        .unwrap();
+}

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -3,11 +3,17 @@
 DIRECTION_NAMES = { "South", "North", "East", "West", "Southeast", "Southwest", "Northeast", "Northwest" }
 DIALOG_NAME = "DMI Editor"
 TEMP_NAME = "aseprite-dmi"
-LUA_LIB = app.fs.pathSeparator ~= "/" and "lua54.dll" or nil -- Handled by linker on posix
-DMI_LIB = app.fs.pathSeparator ~= "/" and "dmi.dll"
-	 or package.cpath:find("%.dylib") and "libdmi.dylib"
+
+IS_POSIX = app.fs.pathSeparator == "/"
+IS_DARWIN = IS_POSIX and package.cpath:find("%.dylib") ~= nil
+
+LUA_LIB = not IS_POSIX and "lua54.dll" or nil -- Handled by linker on posix
+DMI_LIB = not IS_POSIX and "dmi.dll"
+	 or IS_DARWIN and "libdmi.dylib"
 	 or "libdmi.so"
-TEMP_DIR = app.fs.joinPath(app.fs.tempPath, TEMP_NAME)
+
+TEMP_ROOT = IS_DARWIN and (os.getenv("TMPDIR") or app.fs.tempPath) or app.fs.tempPath
+TEMP_DIR = app.fs.joinPath(TEMP_ROOT, TEMP_NAME)
 
 COMMON_STATE = {
 	normal = { part = "sunken_normal", color = "button_normal_text" },

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -3,8 +3,10 @@
 DIRECTION_NAMES = { "South", "North", "East", "West", "Southeast", "Southwest", "Northeast", "Northwest" }
 DIALOG_NAME = "DMI Editor"
 TEMP_NAME = "aseprite-dmi"
-LUA_LIB = app.fs.pathSeparator ~= "/" and "lua54" or nil
-DMI_LIB = app.fs.pathSeparator ~= "/" and "dmi" or "libdmi"
+LUA_LIB = app.fs.pathSeparator ~= "/" and "lua54.dll" or nil -- Handled by linker on posix
+DMI_LIB = app.fs.pathSeparator ~= "/" and "dmi.dll"
+	 or package.cpath:find("%.dylib") and "libdmi.dylib"
+	 or "libdmi.so"
 TEMP_DIR = app.fs.joinPath(app.fs.tempPath, TEMP_NAME)
 
 COMMON_STATE = {

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -33,6 +33,8 @@ function init(plugin)
 		return app.alert { title = DIALOG_NAME, text = "This extension requires Aseprite v1.3.18 or later." }
 	end
 
+	app.fs.makeDirectory(TEMP_DIR)
+
 	-- Initialize Preferences
 	Preferences.initialize(plugin)
 	RawDmi.initialize(plugin.path)


### PR DESCRIPTION
I haven't tested the steam build, but this makes the library able to load on Linux/macOS. MacOS still has other issues making it not work.

The library still needs to be renamed for this to work, it's looking for `libdmi` rather than `libdmi.so`/`libdmi.dylib`.